### PR TITLE
Add ITenant extension to enable local creation of object

### DIFF
--- a/src/SaasKit.Multitenancy/ITenantExtensions.cs
+++ b/src/SaasKit.Multitenancy/ITenantExtensions.cs
@@ -1,0 +1,12 @@
+﻿using SaasKit.Multitenancy.Internal;
+
+namespace SaasKit.Multitenancy
+{
+    public static class ITenant
+    {
+        public static ITenant<ITenant> Create<ITenant>(ITenant tenant) where ITenant : class, new()
+        {
+            return new TenantWrapper<ITenant>(tenant);
+        }
+    }
+}

--- a/tests/SaasKit.Multitenancy.Tests/ITenantExtensionsTests.cs
+++ b/tests/SaasKit.Multitenancy.Tests/ITenantExtensionsTests.cs
@@ -1,0 +1,22 @@
+﻿using Xunit;
+
+namespace SaasKit.Multitenancy.Tests
+{
+    public class ITenantExtensionsTests
+    {
+        [Fact]
+        public void Can_Create_Local_Tenant()
+        {
+            var tenantName = "Tenant 1";
+
+            ITenant<AppTenant> tenant = ITenant.Create(new AppTenant { Name = tenantName });
+
+            Assert.Equal(tenantName, tenant.Value.Name);
+        }
+    }
+
+    public class AppTenant
+    {
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
First pull request so let me know if I got something wrong =)

While building out Unit Tests for MVC and Web API controllers that have ITenant<AppTenant> injected into the constructor I couldn't see anyway to manually create an instance of ITenant<AppTenant> to pass to the controller constructor (possibly there is and I missed it and this change can be discarded).

This is an awesome project and I would be delighted to contribute where I can.

Thanks,
Steven
